### PR TITLE
Fix URLs to include skillzor routes

### DIFF
--- a/undiscriminate/urls.py
+++ b/undiscriminate/urls.py
@@ -1,15 +1,7 @@
 from django.contrib import admin
 from django.urls import path, include
-from rest_framework.routers import DefaultRouter
-
-# Import your viewsets here
-# from skillzor.views import YourViewSet
-
-router = DefaultRouter()
-# Register your viewsets here
-# router.register(r'your_endpoint', YourViewSet)
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path("api/", include(router.urls)),  # Ensure this is included
-    ]
+    path("api/", include("skillzor.urls")),
+]


### PR DESCRIPTION
## Summary
- wire skillzor.urls into root URL config

## Testing
- `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics` *(fails: command not found)*
- `flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aacfc8af08321b50ff7a6d11c9b1f