### PR TITLE
Add agent section to README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# Agent Instructions
+
+## Collaboration Overview
+- You are an expert in Django REST framework.
+- When modifying models, always create and apply migrations (`pipenv run python manage.py makemigrations` and `pipenv run python manage.py migrate`).
+- Maintain a strong focus on security. Implement best practices for authentication, authorization, and secure coding.
+- Avoid structural bias in data models and consider accessibility in API design.
+
+## Setup
+1. Install dependencies:
+   ```bash
+   pipenv install --dev
+   ```
+2. Run formatting and static checks:
+   ```bash
+   pipenv run black .
+   pipenv run flake8
+   ```
+3. Run tests:
+   ```bash
+   pipenv run pytest
+   ```
+
+## Knowledge Base
+- `background/` contains domain PDFs and notes.
+- `plugins/` stores plugin documentation and configuration.
+
+**Note:** AGENTS.md and the contents of `background/` and `plugins/` are for maintainers only. Ensure they are excluded from production container images.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Undiscriminating Discriminator is an MVP prototype exploring a least-discriminat
 - Data fixtures for rapid testing and demonstration.
 - Modular design supporting extension with additional AI/ML models and fairness frameworks.
 
+## LLM Code Assistant Collaboration
+This repository is designed for iterative development with LLM-based code assistant agents. Guidelines for maintainers and agents reside in [AGENTS.md](AGENTS.md). Additional context is stored in `background/` and plugin documentation in `plugins/`. These directories are development-only resources and should be excluded from runtime containers.
+
 ## Tech Stack
 - Python 3.12
 - Django 5.2

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,3 @@
+# Plugins
+
+This directory contains plugin documentation and configuration.

--- a/undiscriminate/skillzor/tests/test_employee_endpoint.py
+++ b/undiscriminate/skillzor/tests/test_employee_endpoint.py
@@ -2,9 +2,12 @@ import pytest
 from rest_framework.test import APIClient
 from skillzor.models import Employee
 
+
 @pytest.mark.django_db
 def test_employee_list_returns_200():
-    Employee.objects.create(first_name="Test", last_name="User", department="IT", job_title="Dev")
+    Employee.objects.create(
+        first_name="Test", last_name="User", department="IT", job_title="Dev"
+    )
     client = APIClient()
     response = client.get("/employees/")
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- document LLM collaboration goals in README
- format test file with `black`

## Testing
- `pipenv run black .`
- `pipenv run flake8` *(fails with E501 line length warnings)*
- `pipenv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_684ab7ed76b88321b05c174282c50a91