### PR TITLE
Apply API prefix and env-based settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+DEBUG=True
+SECRET_KEY=insecure-placeholder-secret
+ALLOWED_HOSTS=localhost,127.0.0.1
+DATABASE_URL=sqlite:///db.sqlite3

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This repository is designed for iterative development with LLM-based code assist
    ```ini
    DEBUG=True
    SECRET_KEY=your-secret-key
+   ALLOWED_HOSTS=localhost,127.0.0.1
    DATABASE_URL=sqlite:///db.sqlite3
    ```
 4. Apply migrations and load sample data:
@@ -55,7 +56,7 @@ Start the development server:
 ```bash
 python manage.py runserver
 ```
-Visit `http://127.0.0.1:8000/` for the API root, or navigate to specific endpoints (see **API Endpoints** below).
+Visit `http://127.0.0.1:8000/api/` for the API root, or navigate to specific endpoints (see **API Endpoints** below).
 
 ## API Endpoints
 | Resource                 | Endpoint                       | Methods       |

--- a/undiscriminate/skillzor/tests/test_employee_endpoint.py
+++ b/undiscriminate/skillzor/tests/test_employee_endpoint.py
@@ -1,5 +1,6 @@
 import pytest
 from rest_framework.test import APIClient
+from django.contrib.auth.models import User
 from skillzor.models import Employee
 
 
@@ -8,6 +9,8 @@ def test_employee_list_returns_200():
     Employee.objects.create(
         first_name="Test", last_name="User", department="IT", job_title="Dev"
     )
+    user = User.objects.create_user(username="tester")
     client = APIClient()
-    response = client.get("/employees/")
+    client.force_authenticate(user=user)
+    response = client.get("/api/employees/")
     assert response.status_code == 200

--- a/undiscriminate/undiscriminate/settings.py
+++ b/undiscriminate/undiscriminate/settings.py
@@ -21,7 +21,9 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.getenv("SECRET_KEY", "insecure-placeholder-secret")
+SECRET_KEY = os.getenv("SECRET_KEY")
+if not SECRET_KEY:
+    raise RuntimeError("The SECRET_KEY environment variable is not set. This is required for security.")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.getenv("DEBUG", "True") == "True"

--- a/undiscriminate/undiscriminate/settings.py
+++ b/undiscriminate/undiscriminate/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
 from pathlib import Path
+import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -20,12 +21,14 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "django-insecure-d$gts%yrd3zad8is%&wl_g+klug3em#thilt86g7fgl%mk^19%"
+SECRET_KEY = os.getenv("SECRET_KEY", "insecure-placeholder-secret")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.getenv("DEBUG", "True") == "True"
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = [
+    host.strip() for host in os.getenv("ALLOWED_HOSTS", "").split(",") if host
+]
 
 
 # Application definition
@@ -132,5 +135,8 @@ REST_FRAMEWORK = {
         "rest_framework.parsers.JSONParser",
         "rest_framework.parsers.FormParser",  # Added to support form data
         "rest_framework.parsers.MultiPartParser",  # Added to support file uploads
+    ],
+    "DEFAULT_PERMISSION_CLASSES": [
+        "rest_framework.permissions.IsAuthenticated",
     ],
 }

--- a/undiscriminate/undiscriminate/urls.py
+++ b/undiscriminate/undiscriminate/urls.py
@@ -1,64 +1,7 @@
-"""
-URL routing for application viewsets.
-"""
-
-from rest_framework.routers import DefaultRouter
 from django.contrib import admin
-from django.urls import path
-from skillzor.views import (
-    EmployeeViewSet,
-    ProjectViewSet,
-    BudgetViewSet,
-    SkillViewSet,
-    EmployeeSkillViewSet,
-    CertificationViewSet,
-    EmployeeCertificationViewSet,
-    DevelopmentActionViewSet,
-)
-
-router = DefaultRouter()
-
-router.register(
-    prefix="employees",
-    viewset=EmployeeViewSet,
-    basename="employees",
-)
-router.register(
-    prefix="projects",
-    viewset=ProjectViewSet,
-    basename="projects",
-)
-router.register(
-    prefix="budgets",
-    viewset=BudgetViewSet,
-    basename="budgets",
-)
-router.register(
-    prefix="skills",
-    viewset=SkillViewSet,
-    basename="skills",
-)
-router.register(
-    prefix="employee-skills",
-    viewset=EmployeeSkillViewSet,
-    basename="employee-skills",
-)
-router.register(
-    prefix="certifications",
-    viewset=CertificationViewSet,
-    basename="certifications",
-)
-router.register(
-    prefix="employee-certifications",
-    viewset=EmployeeCertificationViewSet,
-    basename="employee-certifications",
-)
-router.register(
-    prefix="development-actions",
-    viewset=DevelopmentActionViewSet,
-    basename="development-actions",
-)
+from django.urls import include, path
 
 urlpatterns = [
-    path("admin/", admin.site.urls),  # Add this line for the admin interface
-] + router.urls
+    path("admin/", admin.site.urls),
+    path("api/", include("skillzor.urls")),
+]

--- a/undiscriminate/urls.py
+++ b/undiscriminate/urls.py
@@ -1,7 +1,0 @@
-from django.contrib import admin
-from django.urls import path, include
-
-urlpatterns = [
-    path("admin/", admin.site.urls),
-    path("api/", include("skillzor.urls")),
-]


### PR DESCRIPTION
## Summary
- remove unused URLConf
- enforce API prefix at `/api/`
- read `SECRET_KEY`, `DEBUG`, and `ALLOWED_HOSTS` from environment
- require authentication by default
- update endpoint test for authentication
- document environment variables and update usage instructions
- provide `.env.example`

## Testing
- `pipenv run black .`
- `pipenv run flake8`
- `pipenv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ac01acbb8832187bb0295f681485b