### PR TITLE
Add minimal frontend with Google SSO

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ python manage.py runserver
 ```
 Visit `http://127.0.0.1:8000/api/` for the API root, or navigate to specific endpoints (see **API Endpoints** below).
 
+## Frontend Authentication Example
+A simple page demonstrating Google Single Sign-On is located at `frontend/index.html`.
+Replace `YOUR_GOOGLE_CLIENT_ID` with a client ID from the Google Cloud console
+and open the file in a browser to test the sign-in flow.
+
 ## API Endpoints
 | Resource                 | Endpoint                       | Methods       |
 | ------------------------ | ------------------------------ | ------------- |

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sign in with Google</title>
+    <script src="https://accounts.google.com/gsi/client" async defer></script>
+    <style>
+        body { font-family: sans-serif; margin: 2rem; }
+        pre { background: #f5f5f5; padding: 1rem; }
+    </style>
+    <script>
+      function parseJwt(token) {
+        try {
+          const base64Url = token.split('.')[1];
+          const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+          const jsonPayload = decodeURIComponent(atob(base64).split('').map(c => {
+            return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+          }).join(''));
+          return JSON.parse(jsonPayload);
+        } catch (e) {
+          return null;
+        }
+      }
+      function handleCredentialResponse(response) {
+        const token = response.credential;
+        const info = parseJwt(token);
+        document.getElementById('token').textContent = JSON.stringify(info, null, 2);
+      }
+    </script>
+</head>
+<body>
+    <h1>Google SSO Test</h1>
+    <div id="g_id_onload"
+         data-client_id="YOUR_GOOGLE_CLIENT_ID"
+         data-callback="handleCredentialResponse">
+    </div>
+    <div class="g_id_signin" data-type="standard"></div>
+    <h2>User Info</h2>
+    <pre id="token"></pre>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- provide a very small `frontend/index.html` using Google Identity Services
- document how to test the page in the README

## Testing
- `pipenv run black .`
- `pipenv run flake8`
- `pipenv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_684ad658af708321bdc85ca2db04dff9